### PR TITLE
Add Android/iOS platform support and OS coverage tests

### DIFF
--- a/PinnedMemory.Tests/GlobalUsings.cs
+++ b/PinnedMemory.Tests/GlobalUsings.cs
@@ -1,0 +1,1 @@
+global using Xunit;

--- a/PinnedMemory.Tests/OperatingSystemSupportTests.cs
+++ b/PinnedMemory.Tests/OperatingSystemSupportTests.cs
@@ -1,0 +1,65 @@
+using System;
+using System.Runtime.InteropServices;
+using Xunit;
+
+namespace PinnedMemory.Tests;
+
+public class OperatingSystemSupportTests
+{
+    [Theory]
+    [InlineData(SystemType.Windows, typeof(WindowsMemory))]
+    [InlineData(SystemType.Linux, typeof(LinuxMemory))]
+    [InlineData(SystemType.Osx, typeof(OsxMemory))]
+    [InlineData(SystemType.Android, typeof(AndroidMemory))]
+    [InlineData(SystemType.Ios, typeof(IosMemory))]
+    public void CreateMemory_ReturnsExpectedMemoryImplementation(SystemType type, Type expectedMemoryType)
+    {
+        var memory = PinnedMemory<byte>.CreateMemory(type, _ => false);
+
+        Assert.IsType(expectedMemoryType, memory);
+    }
+
+    [Theory]
+    [InlineData(SystemType.Windows, "WINDOWS")]
+    [InlineData(SystemType.Linux, "LINUX")]
+    [InlineData(SystemType.Osx, "OSX")]
+    [InlineData(SystemType.Android, "ANDROID")]
+    [InlineData(SystemType.Ios, "IOS")]
+    public void ResolveSystemType_DetectsExpectedPlatform(SystemType expectedType, string detectedPlatform)
+    {
+        var actual = PinnedMemory<byte>.ResolveSystemType(
+            SystemType.Unknown,
+            platform => platform.Equals(OSPlatform.Create(detectedPlatform)));
+
+        Assert.Equal(expectedType, actual);
+    }
+
+    [Fact]
+    public void ResolveSystemType_ReturnsUnknown_WhenNoPlatformMatches()
+    {
+        var actual = PinnedMemory<byte>.ResolveSystemType(SystemType.Unknown, _ => false);
+
+        Assert.Equal(SystemType.Unknown, actual);
+    }
+
+    [Fact]
+    public void Constructor_UsesExplicitAndroidTypeWithoutRuntimeDetection()
+    {
+        using var buffer = new PinnedMemory<byte>(new byte[] { 1, 2, 3 }, zero: false, locked: false, type: SystemType.Android);
+
+        Assert.Equal(3, buffer.Length);
+        Assert.Equal((byte)1, buffer[0]);
+    }
+
+    [Fact]
+    public void Constructor_UsesExplicitIosTypeWithoutRuntimeDetection()
+    {
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+            return;
+
+        using var buffer = new PinnedMemory<byte>(new byte[] { 4, 5, 6 }, zero: false, locked: false, type: SystemType.Ios);
+
+        Assert.Equal(3, buffer.Length);
+        Assert.Equal((byte)4, buffer[0]);
+    }
+}

--- a/PinnedMemory.Tests/PinnedMemory.Tests.csproj
+++ b/PinnedMemory.Tests/PinnedMemory.Tests.csproj
@@ -1,0 +1,29 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0" />
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="6.0.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\PinnedMemory\PinnedMemory.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/PinnedMemory.sln
+++ b/PinnedMemory.sln
@@ -7,6 +7,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "PinnedMemory", "PinnedMemor
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PinnedMemory.Examples", "PinnedMemory.Examples\PinnedMemory.Examples.csproj", "{CEF0410B-0F2D-4246-97F3-2D6987058AFF}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PinnedMemory.Tests", "PinnedMemory.Tests\PinnedMemory.Tests.csproj", "{60406976-DEEB-40C7-A23B-3DE02C43FDAB}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -21,6 +23,10 @@ Global
 		{CEF0410B-0F2D-4246-97F3-2D6987058AFF}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{CEF0410B-0F2D-4246-97F3-2D6987058AFF}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{CEF0410B-0F2D-4246-97F3-2D6987058AFF}.Release|Any CPU.Build.0 = Release|Any CPU
+		{60406976-DEEB-40C7-A23B-3DE02C43FDAB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{60406976-DEEB-40C7-A23B-3DE02C43FDAB}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{60406976-DEEB-40C7-A23B-3DE02C43FDAB}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{60406976-DEEB-40C7-A23B-3DE02C43FDAB}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/PinnedMemory/AndroidMemory.cs
+++ b/PinnedMemory/AndroidMemory.cs
@@ -1,0 +1,6 @@
+namespace PinnedMemory
+{
+    public class AndroidMemory : LinuxMemory
+    {
+    }
+}

--- a/PinnedMemory/IosMemory.cs
+++ b/PinnedMemory/IosMemory.cs
@@ -1,0 +1,6 @@
+namespace PinnedMemory
+{
+    public class IosMemory : OsxMemory
+    {
+    }
+}

--- a/PinnedMemory/PinnedMemory.cs
+++ b/PinnedMemory/PinnedMemory.cs
@@ -10,6 +10,9 @@ namespace PinnedMemory
 {
     public class PinnedMemory<T> : IDisposable where T : struct
     {
+        private static readonly OSPlatform AndroidPlatform = OSPlatform.Create("ANDROID");
+        private static readonly OSPlatform IosPlatform = OSPlatform.Create("IOS");
+
         public static Dictionary<Type, int> Types =>
             new Dictionary<Type, int>
             {
@@ -57,23 +60,7 @@ namespace PinnedMemory
             Array.Copy(value, _buffer, value.Length);
             Length = value.Length;
             _locked = locked;
-
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-            {
-                _memory = new WindowsMemory();
-            }
-            else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
-            {
-                _memory = new LinuxMemory();
-            }
-            else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
-            {
-                _memory = new OsxMemory();
-            }
-            else
-            {
-                throw new NotSupportedException("No pinned memory support for current operating system");
-            }
+            _memory = CreateMemory(type, RuntimeInformation.IsOSPlatform);
 
             _handle = GCHandle.Alloc(_buffer, GCHandleType.Pinned);
             var pointer = _handle.AddrOfPinnedObject();
@@ -83,6 +70,45 @@ namespace PinnedMemory
                 _memory.Zero(pointer, context);
             if (_locked)
                 _memory.Lock(pointer, context);
+        }
+
+        internal static SystemType ResolveSystemType(SystemType type, Func<OSPlatform, bool> isOsPlatform)
+        {
+            if (type != SystemType.Unknown)
+                return type;
+
+            if (isOsPlatform(OSPlatform.Windows))
+                return SystemType.Windows;
+            if (isOsPlatform(OSPlatform.Linux))
+                return SystemType.Linux;
+            if (isOsPlatform(OSPlatform.OSX))
+                return SystemType.Osx;
+            if (isOsPlatform(AndroidPlatform))
+                return SystemType.Android;
+            if (isOsPlatform(IosPlatform))
+                return SystemType.Ios;
+
+            return SystemType.Unknown;
+        }
+
+        internal static MemoryBase CreateMemory(SystemType type, Func<OSPlatform, bool> isOsPlatform)
+        {
+            var resolvedType = ResolveSystemType(type, isOsPlatform);
+            switch (resolvedType)
+            {
+                case SystemType.Windows:
+                    return new WindowsMemory();
+                case SystemType.Linux:
+                    return new LinuxMemory();
+                case SystemType.Osx:
+                    return new OsxMemory();
+                case SystemType.Android:
+                    return new AndroidMemory();
+                case SystemType.Ios:
+                    return new IosMemory();
+                default:
+                    throw new NotSupportedException("No pinned memory support for current operating system");
+            }
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/PinnedMemory/PinnedMemory.csproj
+++ b/PinnedMemory/PinnedMemory.csproj
@@ -20,4 +20,10 @@
     </None>
   </ItemGroup>
 
+  <ItemGroup>
+    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
+      <_Parameter1>PinnedMemory.Tests</_Parameter1>
+    </AssemblyAttribute>
+  </ItemGroup>
+
 </Project>

--- a/PinnedMemory/SystemType.cs
+++ b/PinnedMemory/SystemType.cs
@@ -5,6 +5,8 @@
         Unknown = 0,
         Windows = 1,
         Linux = 2,
-        Osx = 3
+        Osx = 3,
+        Android = 4,
+        Ios = 5
     }
 }

--- a/README.md
+++ b/README.md
@@ -68,6 +68,8 @@ Install-Package PinnedMemory
 - Windows
 - Linux
 - macOS
+- Android
+- iOS
 
 ### Supported `T` element types
 
@@ -124,7 +126,7 @@ PinnedMemory(T[] value, bool zero = true, bool locked = true, SystemType type = 
 - `locked`:
   - `true` (default): attempts OS-level page lock.
   - `false`: skip lock attempt.
-- `type`: currently not required for runtime behavior; OS is detected automatically.
+- `type`: optional explicit OS selection (`Windows`, `Linux`, `Osx`, `Android`, `Ios`); when `Unknown`, OS is detected automatically at runtime.
 
 ### Important lifecycle semantics
 


### PR DESCRIPTION
### Motivation

- Provide Android and iOS platform support parallel to Windows/Linux/macOS so mobile targets can be selected or detected; and add automated coverage for OS selection and mapping logic.
- Allow consumers to explicitly select an OS via the constructor `type` parameter in addition to runtime detection for easier testing and deterministic behavior.

### Description

- Extended `SystemType` enum with `Android` and `Ios` values and updated `README.md` platform/constructor docs to include mobile platforms. 
- Added `AndroidMemory` (derives from `LinuxMemory`) and `IosMemory` (derives from `OsxMemory`) implementations following existing OS-specific patterns. 
- Refactored `PinnedMemory<T>` to add `AndroidPlatform`/`IosPlatform` (`OSPlatform.Create(...)`), and introduced `ResolveSystemType` and `CreateMemory` helpers used by the constructor so explicit `SystemType` overrides and runtime detection are supported. 
- Added `InternalsVisibleTo` entry to the library project and a new xUnit test project `PinnedMemory.Tests` with `OperatingSystemSupportTests.cs` to validate OS resolution, implementation mapping and constructor behavior (iOS constructor test is guarded to only run on macOS). 

### Testing

- Installed .NET 8 SDK (`dotnet-sdk-8.0`) in the environment and verified `dotnet --info` (SDK: 8.0.124).
- Ran `dotnet test PinnedMemory.sln`; after adjusting the iOS constructor test to skip on non-OSX platforms (to avoid attempting to call macOS native symbols on Linux), the test run completed successfully with all tests passing (`13 passed`).
- An initial test run surfaced a native loader error for `libSystem` when exercising iOS/macOS native P/Invokes on Linux, which was resolved by the platform guard in the test.