### PR TITLE
Modernize project defaults for .NET 8 and update runtime practices

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,9 @@
+<Project>
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <LangVersion>latest</LangVersion>
+    <AnalysisLevel>latest</AnalysisLevel>
+  </PropertyGroup>
+</Project>

--- a/PinnedMemory.Examples/PinnedMemory.Examples.csproj
+++ b/PinnedMemory.Examples/PinnedMemory.Examples.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/PinnedMemory.Tests/PinnedMemory.Tests.csproj
+++ b/PinnedMemory.Tests/PinnedMemory.Tests.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 

--- a/PinnedMemory/LinuxMemory.cs
+++ b/PinnedMemory/LinuxMemory.cs
@@ -47,7 +47,7 @@ namespace PinnedMemory
         {
         }
 
-        private static string LinuxLockMemory(IntPtr m, UIntPtr l)
+        private static string? LinuxLockMemory(IntPtr m, UIntPtr l)
         {
             if (LinuxMlock(m, l) != 0)
             {
@@ -102,7 +102,7 @@ namespace PinnedMemory
             return success;
         }
 
-        private static string LinuxStrError(int errno)
+        private static string? LinuxStrError(int errno)
         {
             var buf = new byte[256];
             var bufHandle = GCHandle.Alloc(buf, GCHandleType.Pinned);

--- a/PinnedMemory/MemoryBase.cs
+++ b/PinnedMemory/MemoryBase.cs
@@ -11,7 +11,7 @@ namespace PinnedMemory
 {
     public class MemoryBase
     {
-        public MemoryBase(Action<IntPtr, UIntPtr> zeroed, Func<IntPtr, UIntPtr, string> locked, Action<IntPtr, UIntPtr> unlocked)
+        public MemoryBase(Action<IntPtr, UIntPtr> zeroed, Func<IntPtr, UIntPtr, string?> locked, Action<IntPtr, UIntPtr> unlocked)
         {
             Zero = zeroed;
             Lock = locked;
@@ -19,7 +19,7 @@ namespace PinnedMemory
         }
 
         public Action<IntPtr, UIntPtr> Zero { get; protected set; }
-        public Func<IntPtr, UIntPtr, string> Lock { get; protected set; }
+        public Func<IntPtr, UIntPtr, string?> Lock { get; protected set; }
         public Action<IntPtr, UIntPtr> Unlock { get; protected set; }
     }
 }

--- a/PinnedMemory/PinnedMemory.cs
+++ b/PinnedMemory/PinnedMemory.cs
@@ -1,178 +1,205 @@
-﻿using System;
+using System;
+using System.Buffers;
 using System.Collections.Generic;
 using System.Linq;
-using System.Runtime.InteropServices;
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 using System.Security;
-using System.Buffers;
 
-namespace PinnedMemory
+namespace PinnedMemory;
+
+public sealed class PinnedMemory<T> : IDisposable where T : struct
 {
-    public class PinnedMemory<T> : IDisposable where T : struct
+    private static readonly OSPlatform AndroidPlatform = OSPlatform.Create("ANDROID");
+    private static readonly OSPlatform IosPlatform = OSPlatform.Create("IOS");
+
+    private static readonly IReadOnlyDictionary<Type, int> s_types = new Dictionary<Type, int>
     {
-        private static readonly OSPlatform AndroidPlatform = OSPlatform.Create("ANDROID");
-        private static readonly OSPlatform IosPlatform = OSPlatform.Create("IOS");
+        { typeof(sbyte), sizeof(sbyte) },
+        { typeof(byte), sizeof(byte) },
+        { typeof(char), sizeof(char) },
+        { typeof(short), sizeof(short) },
+        { typeof(ushort), sizeof(ushort) },
+        { typeof(int), sizeof(int) },
+        { typeof(uint), sizeof(uint) },
+        { typeof(long), sizeof(long) },
+        { typeof(ulong), sizeof(ulong) },
+        { typeof(float), sizeof(float) },
+        { typeof(double), sizeof(double) },
+        { typeof(decimal), sizeof(decimal) },
+        { typeof(bool), sizeof(bool) }
+    };
 
-        public static Dictionary<Type, int> Types =>
-            new Dictionary<Type, int>
-            {
-                {typeof(sbyte), sizeof(sbyte)},
-                {typeof(byte), sizeof(byte)},
-                {typeof(char), sizeof(char)},
-                {typeof(short), sizeof(short)},
-                {typeof(ushort), sizeof(ushort)},
-                {typeof(int), sizeof(int)},
-                {typeof(uint), sizeof(uint)},
-                {typeof(long), sizeof(long)},
-                {typeof(ulong), sizeof(ulong)},
-                {typeof(float), sizeof(float)},
-                {typeof(double), sizeof(double)},
-                {typeof(decimal), sizeof(decimal)},
-                {typeof(bool), sizeof(bool)}
-            };
+    public static IReadOnlyDictionary<Type, int> Types => s_types;
 
-        private GCHandle _handle;
-        private readonly T[] _buffer;
-        private readonly int _size;
-        private readonly bool _locked;
-        private readonly MemoryBase _memory;
-        private readonly object _lock = new object();
-        private static readonly ArrayPool<T> _pool = ArrayPool<T>.Shared;
-        private bool _disposed = false;
+    private static readonly ArrayPool<T> Pool = ArrayPool<T>.Shared;
 
-        public T this[int i]
+    private GCHandle _handle;
+    private readonly T[] _buffer;
+    private readonly int _size;
+    private readonly bool _locked;
+    private readonly MemoryBase _memory;
+    private bool _disposed;
+
+    public T this[int i]
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        get
         {
-            [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            get => _buffer[i];
-            [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            set => _buffer[i] = value;
+            ThrowIfDisposed();
+            return _buffer[i];
+        }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        set
+        {
+            ThrowIfDisposed();
+            _buffer[i] = value;
+        }
+    }
+
+    public int Length { get; }
+
+    public PinnedMemory(T[] value, bool zero = true, bool locked = true, SystemType type = SystemType.Unknown)
+    {
+        ArgumentNullException.ThrowIfNull(value);
+
+        if (!Types.TryGetValue(typeof(T), out _size))
+        {
+            throw new ArrayTypeMismatchException(
+                $"{nameof(T)} is not a supported pinned memory type. Supported types are: {string.Join(", ", Types.Keys.Select(t => t.Name))}");
         }
 
-        public int Length { get; }
+        _buffer = Pool.Rent(value.Length);
+        Array.Copy(value, _buffer, value.Length);
+        Length = value.Length;
+        _locked = locked;
+        _memory = CreateMemory(type, RuntimeInformation.IsOSPlatform);
 
-        public PinnedMemory(T[] value, bool zero = true, bool locked = true, SystemType type = SystemType.Unknown)
+        _handle = GCHandle.Alloc(_buffer, GCHandleType.Pinned);
+        var pointer = _handle.AddrOfPinnedObject();
+        var context = new UIntPtr((uint)(_size * Length));
+
+        if (zero)
+            _memory.Zero(pointer, context);
+        if (_locked)
+            _memory.Lock(pointer, context);
+    }
+
+    internal static SystemType ResolveSystemType(SystemType type, Func<OSPlatform, bool> isOsPlatform)
+    {
+        if (type != SystemType.Unknown)
+            return type;
+
+        if (isOsPlatform(OSPlatform.Windows))
+            return SystemType.Windows;
+        if (isOsPlatform(OSPlatform.Linux))
+            return SystemType.Linux;
+        if (isOsPlatform(OSPlatform.OSX))
+            return SystemType.Osx;
+        if (isOsPlatform(AndroidPlatform))
+            return SystemType.Android;
+        if (isOsPlatform(IosPlatform))
+            return SystemType.Ios;
+
+        return SystemType.Unknown;
+    }
+
+    internal static MemoryBase CreateMemory(SystemType type, Func<OSPlatform, bool> isOsPlatform)
+    {
+        var resolvedType = ResolveSystemType(type, isOsPlatform);
+        return resolvedType switch
         {
-            if (!Types.TryGetValue(typeof(T), out _size))
-                throw new ArrayTypeMismatchException(
-                    $"{nameof(T)} is not a supported pinned memory type. Supported types are: {string.Join(", ", Types.Keys.Select(t => t.Name))}");
+            SystemType.Windows => new WindowsMemory(),
+            SystemType.Linux => new LinuxMemory(),
+            SystemType.Osx => new OsxMemory(),
+            SystemType.Android => new AndroidMemory(),
+            SystemType.Ios => new IosMemory(),
+            _ => throw new NotSupportedException("No pinned memory support for current operating system")
+        };
+    }
 
-            _buffer = _pool.Rent(value.Length);
-            Array.Copy(value, _buffer, value.Length);
-            Length = value.Length;
-            _locked = locked;
-            _memory = CreateMemory(type, RuntimeInformation.IsOSPlatform);
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public T[] Read()
+    {
+        ThrowIfDisposed();
+        return _buffer;
+    }
 
-            _handle = GCHandle.Alloc(_buffer, GCHandleType.Pinned);
-            var pointer = _handle.AddrOfPinnedObject();
-            var context = new UIntPtr((uint)(_size * Length));
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public T Read(int index)
+    {
+        ThrowIfDisposed();
+        return _buffer[index];
+    }
 
-            if (zero)
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void Write(int index, T value)
+    {
+        ThrowIfDisposed();
+        _buffer[index] = value;
+    }
+
+    public PinnedMemory<T> Clone()
+    {
+        ThrowIfDisposed();
+
+        var buffer = new T[Length];
+        if (typeof(T).IsPrimitive)
+            Buffer.BlockCopy(_buffer, 0, buffer, 0, _buffer.Length * _size);
+        else
+            Array.Copy(_buffer, buffer, _buffer.Length);
+
+        return new PinnedMemory<T>(buffer, false);
+    }
+
+    public T[] ToArray()
+    {
+        ThrowIfDisposed();
+        return _buffer;
+    }
+
+    public override string ToString() => throw new SecurityException("Can't be expressed as String.");
+
+    public void Dispose()
+    {
+        Dispose(disposing: true);
+        GC.SuppressFinalize(this);
+    }
+
+    ~PinnedMemory()
+    {
+        Dispose(disposing: false);
+    }
+
+    private void Dispose(bool disposing)
+    {
+        if (_disposed)
+            return;
+
+        if (_handle.IsAllocated)
+        {
+            try
+            {
+                var pointer = _handle.AddrOfPinnedObject();
+                var context = new UIntPtr((uint)(_size * Length));
+
                 _memory.Zero(pointer, context);
-            if (_locked)
-                _memory.Lock(pointer, context);
-        }
-
-        internal static SystemType ResolveSystemType(SystemType type, Func<OSPlatform, bool> isOsPlatform)
-        {
-            if (type != SystemType.Unknown)
-                return type;
-
-            if (isOsPlatform(OSPlatform.Windows))
-                return SystemType.Windows;
-            if (isOsPlatform(OSPlatform.Linux))
-                return SystemType.Linux;
-            if (isOsPlatform(OSPlatform.OSX))
-                return SystemType.Osx;
-            if (isOsPlatform(AndroidPlatform))
-                return SystemType.Android;
-            if (isOsPlatform(IosPlatform))
-                return SystemType.Ios;
-
-            return SystemType.Unknown;
-        }
-
-        internal static MemoryBase CreateMemory(SystemType type, Func<OSPlatform, bool> isOsPlatform)
-        {
-            var resolvedType = ResolveSystemType(type, isOsPlatform);
-            switch (resolvedType)
+                if (_locked)
+                    _memory.Unlock(pointer, context);
+            }
+            finally
             {
-                case SystemType.Windows:
-                    return new WindowsMemory();
-                case SystemType.Linux:
-                    return new LinuxMemory();
-                case SystemType.Osx:
-                    return new OsxMemory();
-                case SystemType.Android:
-                    return new AndroidMemory();
-                case SystemType.Ios:
-                    return new IosMemory();
-                default:
-                    throw new NotSupportedException("No pinned memory support for current operating system");
+                _handle.Free();
+                Pool.Return(_buffer, clearArray: true);
             }
         }
 
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public T[] Read()
-        {
-            return _buffer;
-        }
+        _disposed = true;
+    }
 
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public T Read(int index)
-        {
-            return _buffer[index];
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public void Write(int index, T value)
-        {
-            _buffer[index] = value;
-        }
-
-        public PinnedMemory<T> Clone()
-        {
-            var buffer = new T[Length];
-            if (typeof(T).IsPrimitive)
-                Buffer.BlockCopy(_buffer, 0, buffer, 0, _buffer.Length * _size);
-            else
-                Array.Copy(_buffer, buffer, _buffer.Length);
-
-            return new PinnedMemory<T>(buffer, false);
-        }
-
-        public T[] ToArray()
-        {
-            return _buffer;
-        }
-
-        public override string ToString()
-        {
-            throw new SecurityException("Can't be expressed as String.");
-        }
-
-        public void Dispose()
-        {
-            if (_disposed)
-                return;
-
-            if (_handle.IsAllocated)
-            {
-                try
-                {
-                    var pointer = _handle.AddrOfPinnedObject();
-                    var context = new UIntPtr((uint)(_size * Length));
-
-                    _memory.Zero(pointer, context);
-                    if (_locked)
-                        _memory.Unlock(pointer, context);
-                }
-                finally
-                {
-                    _handle.Free();
-                    _pool.Return(_buffer);
-                }
-            }
-            _disposed = true;
-        }
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private void ThrowIfDisposed()
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
     }
 }

--- a/PinnedMemory/PinnedMemory.csproj
+++ b/PinnedMemory/PinnedMemory.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8</TargetFramework>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Authors>Timothy D Meadows II</Authors>
     <Company>Timothy D Meadows II</Company>

--- a/PinnedMemory/WindowsMemory.cs
+++ b/PinnedMemory/WindowsMemory.cs
@@ -17,9 +17,9 @@ namespace PinnedMemory
         private static readonly object SetProcessWorkingSetSizeLock = new object();
         private static readonly object VirtualAllocLock = new object();
         private static bool? _is32BitSubsystem;
-        private static GetProcessWorkingSetSizeExDelegate _getProcessWorkingSetSize;
-        private static Func<IntPtr, ulong, ulong, uint, bool> _setProcessWorkingSetSize;
-        private static Func<IntPtr, ulong, uint, uint, IntPtr> _virtualAlloc;
+        private static GetProcessWorkingSetSizeExDelegate? _getProcessWorkingSetSize;
+        private static Func<IntPtr, ulong, ulong, uint, bool>? _setProcessWorkingSetSize;
+        private static Func<IntPtr, ulong, uint, uint, IntPtr>? _virtualAlloc;
 
         [DllImport("psapi.dll", CallingConvention = CallingConvention.Winapi, SetLastError = true)]
         private static extern bool GetProcessMemoryInfo(IntPtr hProcess, out ProcessMemoryCounters counters, uint size);

--- a/README.md
+++ b/README.md
@@ -41,6 +41,10 @@ This gives you a safer lifecycle for sensitive data and a predictable address fo
 
 ---
 
+## Target framework
+
+This project targets **.NET 8** (`net8.0`) by default.
+
 ## Install
 
 ### .NET CLI

--- a/global.json
+++ b/global.json
@@ -1,0 +1,6 @@
+{
+  "sdk": {
+    "version": "8.0.418",
+    "rollForward": "latestFeature"
+  }
+}


### PR DESCRIPTION
### Motivation

- Move the repository to .NET 8 and apply modern C#/.NET defaults (nullable, implicit usings, latest language/analysis) to simplify project files and get consistent builds.
- Improve runtime safety and hygiene for the pinned-memory implementation by adopting newer .NET patterns and clearer disposal/cleanup semantics.
- Make local builds reproducible by pinning the SDK version used for testing.

### Description

- Add `Directory.Build.props` to centralize defaults with `TargetFramework` set to `net8.0`, `Nullable` enabled, `ImplicitUsings` enabled, and latest language/analysis settings.
- Add `global.json` to pin the SDK to `8.0.418` and remove per-project `TargetFramework` entries so projects use the repo defaults.
- Modernize `PinnedMemory<T>`: apply file-scoped namespace, make class `sealed`, add `ArgumentNullException.ThrowIfNull` validation, add finalizer + proper dispose pattern with `GC.SuppressFinalize`, add `ThrowIfDisposed` checks, expose type map as `IReadOnlyDictionary`, use `ArrayPool.Return(..., clearArray: true)`, and replace platform selection with a switch expression.
- Align nullability on memory abstractions by updating `MemoryBase` and OS-specific lock/strerror signatures to nullable-aware forms and adjust Windows/Linux files for nullable analysis.
- Update README to explicitly state the default target framework is .NET 8 (`net8.0`).

### Testing

- Installed .NET SDK `8.0.418` using the official `dotnet-install.sh` script and added it to `PATH` for verification.
- Ran `dotnet --info` to confirm the SDK and then ran `dotnet test PinnedMemory.sln`.
- Automated test result: all tests passed (13/13) using .NET 8.